### PR TITLE
Add automated tests for lookup counters

### DIFF
--- a/main.c
+++ b/main.c
@@ -72,19 +72,19 @@ int main(void) {
         }
 
         // 그 외엔 좌표 조회
+        // 조회 시도마다 카운터를 증가시킨다 (hit/miss 모두 포함)
+        counter_increment(input);
+
         double t0 = current_time_ns();
-        bool found = false;
 
         // 1) 캐시 조회
         if (cache_lookup(input, value)) {
-            found = true;
             double t1 = current_time_ns();
             printf("CACHE HIT : \"%s\" -> \"%s\" (%.0f ns)\n",
                    input, value, t1 - t0);
         }
         // 2) 캐시 미스 → DB 조회
         else if (db_lookup(input, value)) {
-            found = true;
             cache_insert(input, value);
             double t1 = current_time_ns();
             printf("CACHE MISS: Load from DB -> \"%s\" (%.0f ns)\n",
@@ -97,10 +97,7 @@ int main(void) {
                    input, t1 - t0);
         }
 
-        // 조회 성공한 키만 카운터 집계
-        if (found) {
-            counter_increment(input);
-        }
+        // 위 출력 이후 다음 루프 진행
     }
 
     // 종료 직전: 캐시 저장 및 출력

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,10 @@
+# Tests
+
+Run `./tests/run_tests.sh` from the repository root. The script builds the
+program, performs about 50 lookups (half hits and half misses), and prints the
+average latency for cache hits vs misses. It also verifies that counters
+increment for every lookup and that expired cache entries are not reloaded.
+
+```sh
+./tests/run_tests.sh
+```

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+set -e
+
+# build the program
+gcc -std=c11 -D_POSIX_C_SOURCE=200809L -O2 -o coord_finder main.c cache.c db.c counter.c
+
+# start from a clean state
+rm -f cache_state.db counter_state.db out.txt
+
+# pre-populate cache with a valid entry for hq1 and an expired entry for TTL test
+now=$(date +%s)
+printf '%s hq1 37.618367 127.496473\n0 oldkey oldvalue\n' "$now" > cache_state.db
+
+# run about 50 lookups: 25 hits (hq1) and 25 misses (badkey)
+{
+    for i in $(seq 1 25); do
+        echo hq1
+    done
+    for i in $(seq 1 25); do
+        echo badkey
+    done
+    echo exit
+} | ./coord_finder > out.txt
+
+# compute average times in nanoseconds
+hit_avg=$(grep 'CACHE HIT' out.txt | sed 's/.*(\([0-9]*\) ns).*/\1/' | awk '{sum+=$1} END {if (NR>0) printf "%.0f", sum/NR; else print 0}')
+miss_avg=$(grep -E 'CACHE MISS|NOT FOUND' out.txt | sed 's/.*(\([0-9]*\) ns).*/\1/' | awk '{sum+=$1} END {if (NR>0) printf "%.0f", sum/NR; else print 0}')
+
+printf 'Average hit time: %s ns\n' "$hit_avg"
+printf 'Average miss time: %s ns\n' "$miss_avg"
+
+# verify counter increments
+hq1_count=$(grep '^hq1 ' counter_state.db | awk '{print $2}')
+bad_count=$(grep '^badkey ' counter_state.db | awk '{print $2}')
+
+if [ "$hq1_count" = "25" ] && [ "$bad_count" = "25" ]; then
+  echo "Counter increments test: PASS"
+else
+  echo "Counter increments test: FAIL (hq1=$hq1_count badkey=$bad_count)"
+  exit 1
+fi
+
+# verify TTL expiration - oldkey should not survive
+if grep -q 'oldkey' cache_state.db; then
+  echo "TTL expiration test: FAIL"
+  exit 1
+else
+  echo "TTL expiration test: PASS"
+fi
+
+rm -f out.txt
+
+echo "All tests passed."


### PR DESCRIPTION
## Summary
- update main loop to count every lookup
- add test suite under `tests/`
- document how to run the tests

## Testing
- `./tests/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_684f7d77be408320b26022a87311ef2d